### PR TITLE
bugfix: In the operation of `~~`, `ctx.var[xxx]` may be empty and nee…

### DIFF
--- a/apisix/plugins/dynamic-upstream.lua
+++ b/apisix/plugins/dynamic-upstream.lua
@@ -207,6 +207,10 @@ local operator_funcs = {
         return false
     end,
     ["~~"] = function(v2, ctx)
+        if not ctx.var[var[1]] then
+            return false
+        end
+
         local from = re_find(ctx.var[v2[1]], v2[3], "jo")
         if from then
             return true

--- a/apisix/plugins/dynamic-upstream.lua
+++ b/apisix/plugins/dynamic-upstream.lua
@@ -207,7 +207,7 @@ local operator_funcs = {
         return false
     end,
     ["~~"] = function(v2, ctx)
-        if not ctx.var[var[1]] then
+        if not ctx.var[v2[1]] then
             return false
         end
 

--- a/t/plugin/dynamic-upstream.t
+++ b/t/plugin/dynamic-upstream.t
@@ -135,3 +135,70 @@ GET /server_port?name=james
 1980
 --- no_error_log
 [error]
+
+
+
+=== TEST 4: add operation of `~~` in vars
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "dynamic-upstream": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [
+                                                [ "arg_name","~~","[a-z]+" ]                                            
+                                            ]
+                                        }                            
+                                    ],
+                                    "upstreams": [
+                                        {
+                                           "upstream": {
+                                                "name": "upstream_A",
+                                                "type": "roundrobin",
+                                                "nodes": {
+                                                   "127.0.0.1:1981":20
+                                                }
+                                            },
+                                            "weight": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }                    
+                }]]
+                )
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: regular check failed, and return 1980 port.
+--- request
+GET /server_port?name=1234
+--- response_body eval
+1980
+--- no_error_log
+[error]


### PR DESCRIPTION
…ds to be processed.

fix #19